### PR TITLE
fix: the typo of experience

### DIFF
--- a/components/sub/HeroContent.tsx
+++ b/components/sub/HeroContent.tsx
@@ -38,7 +38,7 @@ const HeroContent = () => {
               {" "}
               the best{" "}
             </span>
-            project exprience
+            project experience
           </span>
         </motion.div>
 


### PR DESCRIPTION
This PR Fixes the type of "exprience" to "experience" on the HomePage

Fixes #1
<img width="485" alt="solve" src="https://github.com/user-attachments/assets/6ca2156e-ecfc-473e-8664-2311ab8f77b0" />

- Bug Fix

## Tested
- [ ] Go to HomePage
- [ ] Check the spelling of "experience"


##Mandatory Tasks
-[X] Make sure you self-reviewed the code.